### PR TITLE
Add UTF-8  Charset. That fixes a problem with a dash.

### DIFF
--- a/options/index.html
+++ b/options/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
 <head>
+    <meta charset="utf-8">
     <title>Tab Snooze</title>
     <link rel="stylesheet" href="options.css">
     <link rel="stylesheet" href="/assets/css/bootstrap-timepicker.min.css">


### PR DESCRIPTION
Hey! 
Great extension.
I saw two weird chars in in the settings. I'm located in Switzerland, so I thougt it might be because of different standard encodings. I added the html utf-8 charset and the problem went away.

Keep up the great work!

Screenshot of the problem:
http://imgur.com/W3O0e6S
